### PR TITLE
Endianness and timer improvements

### DIFF
--- a/hw_i2c/sensirion_hw_i2c_implementation.c
+++ b/hw_i2c/sensirion_hw_i2c_implementation.c
@@ -85,6 +85,8 @@ s8 sensirion_i2c_write(u8 address, const u8* data, u16 count)
  * Sleep for a given number of microseconds. The function should delay the
  * execution for at least the given time, but may also sleep longer.
  *
+ * Despite the unit, a <10 millisecond precision is sufficient.
+ *
  * @param useconds the sleep time in microseconds
  */
 void sensirion_sleep_usec(u32 useconds) {

--- a/sensirion_arch_config.h
+++ b/sensirion_arch_config.h
@@ -69,6 +69,32 @@ typedef int8_t s8;
 typedef uint8_t u8;
 
 /**
+ * Define the endianness of your architecture:
+ * 0: little endian, 1: big endian
+ * Use the following code to determine if unsure:
+ * ```c
+ * #include <stdio.h>
+ *
+ * int is_big_endian(void) {
+ *     union {
+ *         unsigned int u;
+ *         char c[sizeof(unsigned int)];
+ *     } e = { 0 };
+ *     e.c[0] = 1;
+ *
+ *     return (e.i != 1);
+ * }
+ *
+ * int main(void) {
+ *     printf("Use #define SENSIRION_BIG_ENDIAN %d\n", is_big_endian());
+ *
+ *     return 0;
+ * }
+ * ```
+ */
+#define SENSIRION_BIG_ENDIAN 0
+
+/**
  * The clock period of the i2c bus in microseconds. Increase this, if your GPIO
  * ports cannot support a 200 kHz output rate. (2 * 1 / 10usec == 200Khz)
  *

--- a/sensirion_arch_config.h
+++ b/sensirion_arch_config.h
@@ -70,9 +70,12 @@ typedef uint8_t u8;
 
 /**
  * The clock period of the i2c bus in microseconds. Increase this, if your GPIO
- * ports cannot support a 200 kHz output rate.
+ * ports cannot support a 200 kHz output rate. (2 * 1 / 10usec == 200Khz)
+ *
+ * This is only relevant for the sw-i2c HAL (bit-banging on GPIO pins). The
+ * pulse length is half the clock period, the number should thus be even.
  */
-#define I2C_CLOCK_PERIOD_USEC 10
+#define SENSIRION_I2C_CLOCK_PERIOD_USEC 10
 
 #ifdef __cplusplus
 }

--- a/sensirion_common.h
+++ b/sensirion_common.h
@@ -44,7 +44,7 @@ extern "C" {
 #define NULL ((void *)0)
 #endif
 
-#ifdef BIG_ENDIAN
+#if SENSIRION_BIG_ENDIAN
 #define be16_to_cpu(s) (s)
 #define be32_to_cpu(s) (s)
 #define be64_to_cpu(s) (s)

--- a/sw_i2c/sensirion_sw_i2c.c
+++ b/sw_i2c/sensirion_sw_i2c.c
@@ -33,7 +33,7 @@
 #include "sensirion_i2c.h"
 #include "sensirion_sw_i2c_gpio.h"
 
-#define DELAY_USEC (I2C_CLOCK_PERIOD_USEC / 2)
+#define DELAY_USEC (SENSIRION_I2C_CLOCK_PERIOD_USEC / 2)
 
 static s8 sensirion_i2c_write_byte(u8 data)
 {

--- a/sw_i2c/sensirion_sw_i2c_implementation.c
+++ b/sw_i2c/sensirion_sw_i2c_implementation.c
@@ -110,7 +110,13 @@ u8 sensirion_SCL_read()
 
 /**
  * Sleep for a given number of microseconds. The function should delay the
- * execution for at least the given time, but may also sleep longer.
+ * execution approximately the given time.
+ *
+ * The precision needed depends on the desired i2c frequency, i.e. should be
+ * exact to about half a clock cycle (defined in
+ * `SENSIRION_I2C_CLOCK_PERIOD_USEC` in `sensirion_arch_config.h`).
+ *
+ * Example with 400kHz requires a precision of 1 / (2 * 400kHz) == 1.25usec.
  *
  * @param useconds the sleep time in microseconds
  */


### PR DESCRIPTION
* Document precision req. of sensirion_sleep_usec()
* Fix endianness issues when BIG_ENDIAN is defined