### PR TITLE
i2c Clock Stretching, generic Linux GPIO impl, Fix

### DIFF
--- a/sw_i2c/sample-implementations/linux_user_space/sensirion_sw_i2c_implementation.c
+++ b/sw_i2c/sample-implementations/linux_user_space/sensirion_sw_i2c_implementation.c
@@ -1,0 +1,232 @@
+/*
+ * Copyright (c) 2018, Sensirion AG
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of Sensirion AG nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+
+#include <fcntl.h> /* close, open */
+#include <sys/types.h> /* mode_t */
+#include <stdio.h> /* fprintf, perror, stderr */
+#include <string.h> /* strlen */
+#include <unistd.h> /* access, lseek, read, usleep */
+#include <stdlib.h> /* exit */
+
+#include "sensirion_sw_i2c_gpio.h"
+#include "sensirion_arch_config.h"
+
+/*
+ * We use the following names for the two I2C signal lines:
+ * SCL for the clock line
+ * SDA for the data line
+ *
+ * Both lines must be equipped with pull-up resistors appropriate to the bus
+ * frequency.
+ */
+#define GPIO_PIN_SCL 12
+#define GPIO_PIN_SDA 13
+#define GPIO_DIR "/sys/class/gpio/"
+
+#define __str(x) #x
+#define GPIO_PIN_STR(p) __str(p)
+#define GPIO_PIN_SCL_STR GPIO_PIN_STR(GPIO_PIN_SCL)
+#define GPIO_PIN_SDA_STR GPIO_PIN_STR(GPIO_PIN_SDA)
+#define GPIO_ID "gpio"
+#define GPIO(p) GPIO_ID __str(p)
+#define GPIO_PATH(p) GPIO_DIR p
+#define GPIO_EXPORT_PATH GPIO_PATH("export")
+#define GPIO_SCL_DIR GPIO_PATH(GPIO(GPIO_PIN_SCL))
+#define GPIO_SDA_DIR GPIO_PATH(GPIO(GPIO_PIN_SDA))
+#define GPIO_SCL_PATH(d) GPIO_SCL_DIR d
+#define GPIO_SDA_PATH(d) GPIO_SDA_DIR d
+#define GPIO_SCL_DIRECTION GPIO_SCL_PATH("/direction")
+#define GPIO_SDA_DIRECTION GPIO_SDA_PATH("/direction")
+#define GPIO_SCL_VALUE GPIO_SCL_PATH("/value")
+#define GPIO_SDA_VALUE GPIO_SDA_PATH("/value")
+
+#define GPIO_DIRECTION_IN "in"
+#define GPIO_DIRECTION_OUT "out"
+#define GPIO_LOW 0
+
+static int scl_dir_fd;
+static int scl_val_fd;
+static int sda_dir_fd;
+static int sda_val_fd;
+
+static int open_or_exit(const char *path, mode_t mode)
+{
+    int fd = open(path, mode);
+    if (fd < 0) {
+        perror(NULL);
+        fprintf(stderr, "Error opening %s (mode %d)\n", path, mode);
+        exit(-1);
+    }
+    return fd;
+}
+
+static void rev_or_exit(int fd)
+{
+    if (lseek(fd, 0, SEEK_SET) < 0) {
+        perror("Error seeking gpio");
+        exit(-1);
+    }
+}
+
+static void write_or_exit(int fd, const char *buf)
+{
+    size_t len = strlen(buf);
+
+    if (write(fd, buf, len) != len) {
+        perror("Error writing");
+        exit(-1);
+    }
+}
+
+static void gpio_export(const char *path, const char *export_pin)
+{
+    int fd;
+
+    if (access(path, F_OK) == -1) {
+        fd = open_or_exit(GPIO_EXPORT_PATH, O_WRONLY);
+        write_or_exit(fd, export_pin);
+        close(fd);
+    }
+}
+
+static void gpio_set_value(int fd, int value)
+{
+    char buf[] = {'0', '\0'};
+
+    buf[0] += value;
+    rev_or_exit(fd);
+    write_or_exit(fd, buf);
+}
+
+static void gpio_set_direction(int fd, const char *dir)
+{
+    rev_or_exit(fd);
+    write_or_exit(fd, dir);
+}
+
+static char gpio_get_value(int fd)
+{
+    char c;
+
+    rev_or_exit(fd);
+    if (read(fd, &c, 1) != 1) {
+        perror("Error reading GPIO value");
+        exit(-1);
+    }
+    return c == '1';
+}
+
+/**
+ * Initialize all hard- and software components that are needed to set the
+ * SDA and SCL pins.
+ */
+void sensirion_init_pins()
+{
+    gpio_export(GPIO_SCL_DIR, GPIO_PIN_SCL_STR);
+    gpio_export(GPIO_SDA_DIR, GPIO_PIN_SDA_STR);
+
+    scl_dir_fd = open_or_exit(GPIO_SCL_DIRECTION, O_WRONLY);
+    scl_val_fd = open_or_exit(GPIO_SCL_VALUE, O_RDWR);
+    sda_dir_fd = open_or_exit(GPIO_SDA_DIRECTION, O_WRONLY);
+    sda_val_fd = open_or_exit(GPIO_SDA_VALUE, O_RDWR);
+}
+
+/**
+ * Configure the SDA pin as an input. With an external pull-up resistor the line
+ * should be left floating, without external pull-up resistor, the input must be
+ * configured to use the internal pull-up resistor.
+ */
+void sensirion_SDA_in()
+{
+    gpio_set_direction(sda_dir_fd, GPIO_DIRECTION_IN);
+}
+
+/**
+ * Configure the SDA pin as an output and drive it low or set to logical false.
+ */
+void sensirion_SDA_out()
+{
+    gpio_set_direction(sda_dir_fd, GPIO_DIRECTION_OUT);
+    gpio_set_value(sda_val_fd, GPIO_LOW);
+}
+
+/**
+ * Read the value of the SDA pin.
+ * @returns 0 if the pin is low and 1 otherwise.
+ */
+u8 sensirion_SDA_read()
+{
+    return gpio_get_value(sda_val_fd);
+}
+
+/**
+ * Configure the SCL pin as an input. With an external pull-up resistor the line
+ * should be left floating, without external pull-up resistor, the input must be
+ * configured to use the internal pull-up resistor.
+ */
+void sensirion_SCL_in()
+{
+    gpio_set_direction(scl_dir_fd, GPIO_DIRECTION_IN);
+}
+
+/**
+ * Configure the SCL pin as an output and drive it low or set to logical false.
+ */
+void sensirion_SCL_out()
+{
+    gpio_set_direction(scl_dir_fd, GPIO_DIRECTION_OUT);
+    gpio_set_value(scl_val_fd, GPIO_LOW);
+}
+
+/**
+ * Read the value of the SCL pin.
+ * @returns 0 if the pin is low and 1 otherwise.
+ */
+u8 sensirion_SCL_read()
+{
+    return gpio_get_value(scl_val_fd);
+}
+
+/**
+ * Sleep for a given number of microseconds. The function should delay the
+ * execution approximately, but no less than, the given time.
+ *
+ * The precision needed depends on the desired i2c frequency, i.e. should be
+ * exact to about half a clock cycle (defined in
+ * `SENSIRION_I2C_CLOCK_PERIOD_USEC` in `sensirion_arch_config.h`).
+ *
+ * Example with 400kHz requires a precision of 1 / (2 * 400kHz) == 1.25usec.
+ *
+ * @param useconds the sleep time in microseconds
+ */
+void sensirion_sleep_usec(u32 useconds) {
+    usleep(useconds);
+}

--- a/sw_i2c/sensirion_sw_i2c.c
+++ b/sw_i2c/sensirion_sw_i2c.c
@@ -124,6 +124,7 @@ s8 sensirion_i2c_write(u8 address, const u8* data, u16 count)
 s8 sensirion_i2c_read(u8 address, u8* data, u16 count)
 {
     s8 ret;
+    u8 send_ack;
     u16 i;
     sensirion_i2c_start();
     ret = sensirion_i2c_write_byte((address << 1) | 1);
@@ -131,8 +132,10 @@ s8 sensirion_i2c_read(u8 address, u8* data, u16 count)
         sensirion_i2c_stop();
         return ret;
     }
-    for (i = 0; i < count; i++)
-        data[i] = sensirion_i2c_read_byte(1);
+    for (i = 0; i < count; i++) {
+        send_ack = i < (count - 1); /* last byte must be NACK'ed */
+        data[i] = sensirion_i2c_read_byte(send_ack);
+    }
 
     sensirion_i2c_stop();
     return ret;

--- a/sw_i2c/sensirion_sw_i2c.c
+++ b/sw_i2c/sensirion_sw_i2c.c
@@ -178,4 +178,6 @@ s8 sensirion_i2c_read(u8 address, u8* data, u16 count)
 void sensirion_i2c_init()
 {
     sensirion_init_pins();
+    sensirion_SCL_in();
+    sensirion_SDA_in();
 }


### PR DESCRIPTION
* Fix an issue where the last master-read byte was ACK'ed instead of NACK'ed
* Support i2c clock stretching (master hold)
* Provide a generic implementation for sw-i2c using Linux's gpio subsystem (`/sys/class/gpio`)