### PR TITLE
Host-Endian Words

### DIFF
--- a/sensirion_common.h
+++ b/sensirion_common.h
@@ -102,6 +102,23 @@ u16 sensirion_fill_cmd_send_buf(u8 *buf, u16 cmd, const u16 *args, u8 num_args);
 s16 sensirion_i2c_read_words(u8 address, u16 *data_words, u16 num_words);
 
 /**
+ * sensirion_i2c_read_bytes() - read data words as byte-stream from sensor
+ *
+ * Read bytes without adjusting values to the uP's word-order.
+ *
+ * @address:    Sensor i2c address
+ * @data:       Allocated buffer to store the read bytes.
+ *              The buffer may also have been modified on STATUS_FAIL return.
+ * @num_words:  Number of data words(!) to read (without CRC bytes)
+ *              Since only word-chunks can be read from the sensor the size
+ *              is still specified in sensor-words (num_words = num_bytes *
+ *              SENSIRION_WORD_SIZE)
+ *
+ * @return      STATUS_OK on success, an error code otherwise
+ */
+s16 sensirion_i2c_read_bytes(u8 address, u8 *data, u16 num_words);
+
+/**
  * sensirion_i2c_write_cmd() - writes a command to the sensor
  * @address:    Sensor i2c address
  * @command:    Sensor command

--- a/sensirion_common.h
+++ b/sensirion_common.h
@@ -48,13 +48,26 @@ extern "C" {
 #define be16_to_cpu(s) (s)
 #define be32_to_cpu(s) (s)
 #define be64_to_cpu(s) (s)
-#else
+#define SENSIRION_WORDS_TO_BYTES(a, w) ()
+
+#else /* SENSIRION_BIG_ENDIAN */
+
 #define be16_to_cpu(s) (((u16)(s) << 8) | (0xff & ((u16)(s)) >> 8))
 #define be32_to_cpu(s) (((u32)be16_to_cpu(s) << 16) | \
                         (0xffff & (be16_to_cpu((s) >> 16))))
 #define be64_to_cpu(s) (((u64)be32_to_cpu(s) << 32) | \
                         (0xffffffff & ((u64)be32_to_cpu((s) >> 32))))
-#endif
+/**
+ * Convert a word-array to a bytes-array, effectively reverting the
+ * host-endianness to big-endian
+ * @a:  word array to change (must be (u16 *) castable)
+ * @w:  number of word-sized elements in the array (SENSIRION_NUM_WORDS(a)).
+ */
+#define SENSIRION_WORDS_TO_BYTES(a, w) \
+    for (u16 *__a = (u16 *)(a), __e = (w), __w = 0; __w < __e; ++__w) { \
+        __a[__w] = be16_to_cpu(__a[__w]); \
+    }
+#endif /* SENSIRION_BIG_ENDIAN */
 
 #ifndef ARRAY_SIZE
 #define ARRAY_SIZE(x) (sizeof(x) / sizeof(*(x)))


### PR DESCRIPTION
Let word-commands return words in host/system-endianness

Previously the returned words were big-endian causing confusion
between writes that took system-endian values and reads that returned
big-endian values.

Adds sensirion_i2c_read_bytes that returns the (crc-checked) byte stream as
received.

Provide SENSIRION_WORDS_TO_BYES(word_array, num_wods) to convert a
word array back to a bytes array (in the order the bytes arrive on the
wire, i.e. big-endian).