### PR TITLE
Fix sign conversion warnings

### DIFF
--- a/sw_i2c/sensirion_sw_i2c.c
+++ b/sw_i2c/sensirion_sw_i2c.c
@@ -36,7 +36,7 @@
 
 #define DELAY_USEC (SENSIRION_I2C_CLOCK_PERIOD_USEC / 2)
 
-static uint8_t sensirion_wait_while_clock_stretching(void) {
+static int8_t sensirion_wait_while_clock_stretching(void) {
     uint8_t timeout = 100;
 
     while (--timeout) {
@@ -101,7 +101,7 @@ static uint8_t sensirion_i2c_read_byte(uint8_t ack) {
     return data;
 }
 
-static uint8_t sensirion_i2c_start(void) {
+static int8_t sensirion_i2c_start(void) {
     sensirion_SCL_in();
     if (sensirion_wait_while_clock_stretching())
         return STATUS_FAIL;

--- a/sw_i2c/sensirion_sw_i2c.c
+++ b/sw_i2c/sensirion_sw_i2c.c
@@ -82,7 +82,7 @@ static uint8_t sensirion_i2c_read_byte(uint8_t ack) {
         sensirion_sleep_usec(DELAY_USEC);
         sensirion_SCL_in();
         if (sensirion_wait_while_clock_stretching())
-            return STATUS_FAIL;
+            return 0xFF; // return 0xFF on error
         data |= (sensirion_SDA_read() != 0) << i;
         sensirion_SCL_out();
     }
@@ -94,7 +94,7 @@ static uint8_t sensirion_i2c_read_byte(uint8_t ack) {
     sensirion_SCL_in();
     sensirion_sleep_usec(DELAY_USEC);
     if (sensirion_wait_while_clock_stretching())
-        return STATUS_FAIL;
+        return 0xFF; // return 0xFF on error
     sensirion_SCL_out();
     sensirion_SDA_in();
 


### PR DESCRIPTION
The error return value is actually signed. This is not a breaking change, since it only changes internal functions. So no change to the public API.