### PR TITLE
Fix warnings in linux I2C SW sample implementation

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,2 +1,3 @@
 Andreas Brauchli <andreas.brauchli@sensirion.com>
 Christian Jaeggi <christian.jaeggi@sensirion.com>
+Sven Gruebel <sven.gruebel@sensirion.com>

--- a/sw_i2c/sample-implementations/linux_user_space/sensirion_sw_i2c_implementation.c
+++ b/sw_i2c/sample-implementations/linux_user_space/sensirion_sw_i2c_implementation.c
@@ -77,8 +77,8 @@ static int scl_val_fd;
 static int sda_dir_fd;
 static int sda_val_fd;
 
-static int open_or_exit(const char *path, mode_t mode) {
-    int fd = open(path, mode);
+static int open_or_exit(const char *path, int flags) {
+    int fd = open(path, flags);
     if (fd < 0) {
         perror(NULL);
         fprintf(stderr, "Error opening %s (mode %d)\n", path, mode);
@@ -97,7 +97,11 @@ static void rev_or_exit(int fd) {
 static void write_or_exit(int fd, const char *buf) {
     size_t len = strlen(buf);
 
-    if (write(fd, buf, len) != len) {
+    ssize_t w = write(fd, buf, len);
+
+    // Adapted from stackoverflow answer by Stephen Canon
+    // See: https://www.stackoverflow.com/a/16086724
+    if (w < 0 || size_t(w) != len) {
         perror("Error writing");
         exit(-1);
     }


### PR DESCRIPTION
The I2C software sample implementation generated two warnings of type
`sign-conversion` and `sign-compare`. This commit fixes these warnings.