### PR TITLE
Return errors in I2C dummy implementation

### DIFF
--- a/hw_i2c/sensirion_hw_i2c_implementation.c
+++ b/hw_i2c/sensirion_hw_i2c_implementation.c
@@ -31,6 +31,7 @@
 
 #include "sensirion_arch_config.h"
 #include "sensirion_i2c.h"
+#include "sensirion_common.h"
 
 /*
  * INSTRUCTIONS
@@ -52,7 +53,7 @@
  */
 int16_t sensirion_i2c_select_bus(uint8_t bus_idx) {
     // IMPLEMENT or leave empty if all sensors are located on one single bus
-    return 0;
+    return STATUS_FAIL;
 }
 
 /**
@@ -82,7 +83,7 @@ void sensirion_i2c_release(void) {
  */
 int8_t sensirion_i2c_read(uint8_t address, uint8_t *data, uint16_t count) {
     // IMPLEMENT
-    return 0;
+    return STATUS_FAIL;
 }
 
 /**
@@ -99,7 +100,7 @@ int8_t sensirion_i2c_read(uint8_t address, uint8_t *data, uint16_t count) {
 int8_t sensirion_i2c_write(uint8_t address, const uint8_t *data,
                            uint16_t count) {
     // IMPLEMENT
-    return 0;
+    return STATUS_FAIL;
 }
 
 /**


### PR DESCRIPTION
There were cases were people were using the I2C dummy implementation by accident and didn't notice directly, since all I2C calls succeeded.