### PR TITLE
Rename sensirion_i2c_read_bytes to avoid confusion

### DIFF
--- a/sensirion_common.c
+++ b/sensirion_common.c
@@ -83,8 +83,8 @@ uint16_t sensirion_fill_cmd_send_buf(uint8_t *buf, uint16_t cmd,
     return idx;
 }
 
-int16_t sensirion_i2c_read_bytes(uint8_t address, uint8_t *data,
-                                 uint16_t num_words) {
+int16_t sensirion_i2c_read_words_as_bytes(uint8_t address, uint8_t *data,
+                                          uint16_t num_words) {
     int16_t ret;
     uint16_t i, j;
     uint16_t size = num_words * (SENSIRION_WORD_SIZE + CRC8_LEN);
@@ -115,7 +115,8 @@ int16_t sensirion_i2c_read_words(uint8_t address, uint16_t *data_words,
     int16_t ret;
     uint8_t i;
 
-    ret = sensirion_i2c_read_bytes(address, (uint8_t *)data_words, num_words);
+    ret = sensirion_i2c_read_words_as_bytes(address, (uint8_t *)data_words,
+                                            num_words);
     if (ret != STATUS_OK)
         return ret;
 

--- a/sensirion_common.h
+++ b/sensirion_common.h
@@ -117,7 +117,8 @@ int16_t sensirion_i2c_read_words(uint8_t address, uint16_t *data_words,
                                  uint16_t num_words);
 
 /**
- * sensirion_i2c_read_bytes() - read data words as byte-stream from sensor
+ * sensirion_i2c_read_words_as_bytes() - read data words as byte-stream from
+ *                                       sensor
  *
  * Read bytes without adjusting values to the uP's word-order.
  *
@@ -131,8 +132,8 @@ int16_t sensirion_i2c_read_words(uint8_t address, uint16_t *data_words,
  *
  * @return      STATUS_OK on success, an error code otherwise
  */
-int16_t sensirion_i2c_read_bytes(uint8_t address, uint8_t *data,
-                                 uint16_t num_words);
+int16_t sensirion_i2c_read_words_as_bytes(uint8_t address, uint8_t *data,
+                                          uint16_t num_words);
 
 /**
  * sensirion_i2c_write_cmd() - writes a command to the sensor


### PR DESCRIPTION
Rename sensirion_i2c_read_bytes to sensirion_i2c_read_words_as_bytes
to hint that the size parameter is in words and not in bytes.