### PR TITLE
arch_config: Remove float32_t typedef

### DIFF
--- a/sensirion_arch_config.h
+++ b/sensirion_arch_config.h
@@ -68,9 +68,6 @@ extern "C" {
  * typedef char int8_t;
  * typedef unsigned char uint8_t; */
 
-/* Types not typically provided by <stdint.h> */
-typedef float float32_t;
-
 /**
  * Define the endianness of your architecture:
  * 0: little endian, 1: big endian


### PR DESCRIPTION
It isn't used anywhere and float is defined to be a single precision
floating point type and on almost all platforms it is a IEEE-754 32 bit
floating point.