### PR TITLE
Config independent endianness conversion

### DIFF
--- a/sensirion_common.c
+++ b/sensirion_common.c
@@ -38,6 +38,21 @@
 #include "sensirion_common.h"
 #include "sensirion_i2c.h"
 
+uint32_t sensirion_bytes_to_uint32_t(const uint8_t* bytes) {
+    return (uint32_t)bytes[0] << 24 | (uint32_t)bytes[1] << 16 |
+           (uint32_t)bytes[2] << 8 | (uint32_t)bytes[3];
+}
+
+uint32_t sensirion_bytes_to_float(const uint8_t* bytes) {
+    union {
+        uint32_t u32_value;
+        float float32;
+    } tmp;
+
+    tmp.u32_value = sensirion_bytes_to_uint32_t(bytes);
+    return tmp.float32;
+}
+
 uint8_t sensirion_common_generate_crc(const uint8_t* data, uint16_t count) {
     uint16_t current_byte;
     uint8_t crc = CRC8_INIT;

--- a/sensirion_common.c
+++ b/sensirion_common.c
@@ -134,14 +134,17 @@ int16_t sensirion_i2c_read_words(uint8_t address, uint16_t* data_words,
                                  uint16_t num_words) {
     int16_t ret;
     uint8_t i;
+    const uint8_t* word_bytes;
 
     ret = sensirion_i2c_read_words_as_bytes(address, (uint8_t*)data_words,
                                             num_words);
     if (ret != STATUS_OK)
         return ret;
 
-    for (i = 0; i < num_words; ++i)
-        data_words[i] = be16_to_cpu(data_words[i]);
+    for (i = 0; i < num_words; ++i) {
+        word_bytes = (uint8_t*)&data_words[i];
+        data_words[i] = ((uint16_t)word_bytes[0] << 8) | word_bytes[1];
+    }
 
     return STATUS_OK;
 }

--- a/sensirion_common.h
+++ b/sensirion_common.h
@@ -87,7 +87,7 @@ int8_t sensirion_common_check_crc(const uint8_t* data, uint16_t count,
                                   uint8_t checksum);
 
 /**
- * Send a general call reset.
+ * sensirion_i2c_general_call_reset() - Send a general call reset.
  *
  * @warning This will reset all attached I2C devices on the bus which support
  *          general call reset.

--- a/sensirion_common.h
+++ b/sensirion_common.h
@@ -81,6 +81,28 @@ extern "C" {
 #define SENSIRION_NUM_WORDS(x) (sizeof(x) / SENSIRION_WORD_SIZE)
 #define SENSIRION_MAX_BUFFER_WORDS 32
 
+/**
+ * sensirion_bytes_to_uint32_t() - Convert an array of bytes to an uint32_t
+ *
+ * Convert an array of bytes received from the sensor in big-endian/MSB-first
+ * format to an uint32_t value in the correct system-endianness.
+ *
+ * @param bytes An array of at least four bytes (MSB first)
+ * @return      The byte array represented as uint32_t
+ */
+uint32_t sensirion_bytes_to_uint32_t(const uint8_t* bytes);
+
+/**
+ * sensirion_bytes_to_float() - Convert an array of bytes to an uint32_t
+ *
+ * Convert an array of bytes received from the sensor in big-endian/MSB-first
+ * format to an uint32_t value in the correct system-endianness.
+ *
+ * @param bytes An array of at least four bytes (MSB first)
+ * @return      The byte array represented as uint32_t
+ */
+uint32_t sensirion_bytes_to_float(const uint8_t* bytes);
+
 uint8_t sensirion_common_generate_crc(const uint8_t* data, uint16_t count);
 
 int8_t sensirion_common_check_crc(const uint8_t* data, uint16_t count,


### PR DESCRIPTION
This MR adds and uses new config independent endianness conversion functions

Currently, driver users need to specify whether the use a big or little endian system by defining SENSIRION_BIG_ENDIAN (in sensirion_arch_config.h), this MR initiates the switch over
to using configuration independent functions that use the raw byte strings.

The old conversion functions *_to_cpu (e.g. be16_to_cpu) remain in place for now but should be considered deprecated.

The MR also contains a small Docstring fix I slipped in