### PR TITLE
Add NO_ERROR define and deprecate STATUS_OK

### DIFF
--- a/hw_i2c/sample-implementations/mbed/sgp30_example_usage.cpp
+++ b/hw_i2c/sample-implementations/mbed/sgp30_example_usage.cpp
@@ -44,7 +44,7 @@ int main(void) {
     uint32_t iaq_baseline;
     uint16_t ethanol_signal, h2_signal;
 
-    while (sgp_probe() != STATUS_OK) {
+    while (sgp_probe() != NO_ERROR) {
         pc.printf("SGP sensor probing failed" EOL);
         sensirion_sleep_usec(1000000);
     }
@@ -52,7 +52,7 @@ int main(void) {
 
     /* Read signals */
     err = sgp_measure_signals_blocking_read(&ethanol_signal, &h2_signal);
-    if (err == STATUS_OK) {
+    if (err == NO_ERROR) {
         /* Print ethanol signal and h2 signal */
         pc.printf("Ethanol signal: %u" EOL, ethanol_signal);
         pc.printf("H2 signal: %u" EOL, h2_signal);
@@ -72,7 +72,7 @@ int main(void) {
     /* Run periodic IAQ measurements at defined intervals */
     while (1) {
         err = sgp_measure_iaq_blocking_read(&tvoc_ppb, &co2_eq_ppm);
-        if (err == STATUS_OK) {
+        if (err == NO_ERROR) {
             pc.printf(
                 "tVOC  Concentration: %dppb, CO2eq Concentration: %dppm" EOL,
                 tvoc_ppb, co2_eq_ppm);
@@ -83,7 +83,7 @@ int main(void) {
         /* Persist the current baseline every hour */
         if (++i % 3600 == 3599) {
             err = sgp_get_iaq_baseline(&iaq_baseline);
-            if (err == STATUS_OK) {
+            if (err == NO_ERROR) {
                 /* IMPLEMENT: store baseline to presistent storage */
             }
         }

--- a/sensirion_common.c
+++ b/sensirion_common.c
@@ -75,7 +75,7 @@ int8_t sensirion_common_check_crc(const uint8_t* data, uint16_t count,
                                   uint8_t checksum) {
     if (sensirion_common_generate_crc(data, count) != checksum)
         return STATUS_FAIL;
-    return STATUS_OK;
+    return NO_ERROR;
 }
 
 int16_t sensirion_i2c_general_call_reset(void) {
@@ -112,7 +112,7 @@ int16_t sensirion_i2c_read_words_as_bytes(uint8_t address, uint8_t* data,
     uint8_t* const buf8 = (uint8_t*)word_buf;
 
     ret = sensirion_i2c_read(address, buf8, size);
-    if (ret != STATUS_OK)
+    if (ret != NO_ERROR)
         return ret;
 
     /* check the CRC for each word */
@@ -120,14 +120,14 @@ int16_t sensirion_i2c_read_words_as_bytes(uint8_t address, uint8_t* data,
 
         ret = sensirion_common_check_crc(&buf8[i], SENSIRION_WORD_SIZE,
                                          buf8[i + SENSIRION_WORD_SIZE]);
-        if (ret != STATUS_OK)
+        if (ret != NO_ERROR)
             return ret;
 
         data[j++] = buf8[i];
         data[j++] = buf8[i + 1];
     }
 
-    return STATUS_OK;
+    return NO_ERROR;
 }
 
 int16_t sensirion_i2c_read_words(uint8_t address, uint16_t* data_words,
@@ -138,7 +138,7 @@ int16_t sensirion_i2c_read_words(uint8_t address, uint16_t* data_words,
 
     ret = sensirion_i2c_read_words_as_bytes(address, (uint8_t*)data_words,
                                             num_words);
-    if (ret != STATUS_OK)
+    if (ret != NO_ERROR)
         return ret;
 
     for (i = 0; i < num_words; ++i) {
@@ -146,7 +146,7 @@ int16_t sensirion_i2c_read_words(uint8_t address, uint16_t* data_words,
         data_words[i] = ((uint16_t)word_bytes[0] << 8) | word_bytes[1];
     }
 
-    return STATUS_OK;
+    return NO_ERROR;
 }
 
 int16_t sensirion_i2c_write_cmd(uint8_t address, uint16_t command) {
@@ -174,7 +174,7 @@ int16_t sensirion_i2c_delayed_read_cmd(uint8_t address, uint16_t cmd,
 
     sensirion_fill_cmd_send_buf(buf, cmd, NULL, 0);
     ret = sensirion_i2c_write(address, buf, SENSIRION_COMMAND_SIZE);
-    if (ret != STATUS_OK)
+    if (ret != NO_ERROR)
         return ret;
 
     if (delay_us)

--- a/sensirion_common.h
+++ b/sensirion_common.h
@@ -38,6 +38,8 @@
 extern "C" {
 #endif
 
+#define NO_ERROR 0
+/* deprecated defines, use NO_ERROR or custom error codes instead */
 #define STATUS_OK 0
 #define STATUS_FAIL (-1)
 
@@ -114,7 +116,7 @@ int8_t sensirion_common_check_crc(const uint8_t* data, uint16_t count,
  * @warning This will reset all attached I2C devices on the bus which support
  *          general call reset.
  *
- * @return  STATUS_OK on success, an error code otherwise
+ * @return  NO_ERROR on success, an error code otherwise
  */
 int16_t sensirion_i2c_general_call_reset(void);
 
@@ -143,7 +145,7 @@ uint16_t sensirion_fill_cmd_send_buf(uint8_t* buf, uint16_t cmd,
  *              The buffer may also have been modified on STATUS_FAIL return.
  * @num_words:  Number of data words to read (without CRC bytes)
  *
- * @return      STATUS_OK on success, an error code otherwise
+ * @return      NO_ERROR on success, an error code otherwise
  */
 int16_t sensirion_i2c_read_words(uint8_t address, uint16_t* data_words,
                                  uint16_t num_words);
@@ -162,7 +164,7 @@ int16_t sensirion_i2c_read_words(uint8_t address, uint16_t* data_words,
  *              is still specified in sensor-words (num_words = num_bytes *
  *              SENSIRION_WORD_SIZE)
  *
- * @return      STATUS_OK on success, an error code otherwise
+ * @return      NO_ERROR on success, an error code otherwise
  */
 int16_t sensirion_i2c_read_words_as_bytes(uint8_t address, uint8_t* data,
                                           uint16_t num_words);
@@ -172,7 +174,7 @@ int16_t sensirion_i2c_read_words_as_bytes(uint8_t address, uint8_t* data,
  * @address:    Sensor i2c address
  * @command:    Sensor command
  *
- * @return      STATUS_OK on success, an error code otherwise
+ * @return      NO_ERROR on success, an error code otherwise
  */
 int16_t sensirion_i2c_write_cmd(uint8_t address, uint16_t command);
 
@@ -184,7 +186,7 @@ int16_t sensirion_i2c_write_cmd(uint8_t address, uint16_t command);
  * @data:       Argument buffer with words to send
  * @num_words:  Number of data words to send (without CRC bytes)
  *
- * @return      STATUS_OK on success, an error code otherwise
+ * @return      NO_ERROR on success, an error code otherwise
  */
 int16_t sensirion_i2c_write_cmd_with_args(uint8_t address, uint16_t command,
                                           const uint16_t* data_words,
@@ -199,7 +201,7 @@ int16_t sensirion_i2c_write_cmd_with_args(uint8_t address, uint16_t command,
  * @data_words: Allocated buffer to store the read data
  * @num_words:  Data words to read (without CRC bytes)
  *
- * @return      STATUS_OK on success, an error code otherwise
+ * @return      NO_ERROR on success, an error code otherwise
  */
 int16_t sensirion_i2c_delayed_read_cmd(uint8_t address, uint16_t cmd,
                                        uint32_t delay_us, uint16_t* data_words,
@@ -212,7 +214,7 @@ int16_t sensirion_i2c_delayed_read_cmd(uint8_t address, uint16_t cmd,
  * @data_words: Allocated buffer to store the read data
  * @num_words:  Data words to read (without CRC bytes)
  *
- * @return      STATUS_OK on success, an error code otherwise
+ * @return      NO_ERROR on success, an error code otherwise
  */
 int16_t sensirion_i2c_read_cmd(uint8_t address, uint16_t cmd,
                                uint16_t* data_words, uint16_t num_words);

--- a/sw_i2c/sensirion_sw_i2c.c
+++ b/sw_i2c/sensirion_sw_i2c.c
@@ -42,7 +42,7 @@ static int8_t sensirion_wait_while_clock_stretching(void) {
 
     while (--timeout_cycles) {
         if (sensirion_SCL_read())
-            return STATUS_OK;
+            return NO_ERROR;
         sensirion_sleep_usec(SENSIRION_I2C_CLOCK_PERIOD_USEC);
     }
 
@@ -111,7 +111,7 @@ static int8_t sensirion_i2c_start(void) {
     sensirion_sleep_usec(DELAY_USEC);
     sensirion_SCL_out();
     sensirion_sleep_usec(DELAY_USEC);
-    return STATUS_OK;
+    return NO_ERROR;
 }
 
 static void sensirion_i2c_stop(void) {
@@ -129,17 +129,17 @@ int8_t sensirion_i2c_write(uint8_t address, const uint8_t* data,
     uint16_t i;
 
     ret = sensirion_i2c_start();
-    if (ret != STATUS_OK)
+    if (ret != NO_ERROR)
         return ret;
 
     ret = sensirion_i2c_write_byte(address << 1);
-    if (ret != STATUS_OK) {
+    if (ret != NO_ERROR) {
         sensirion_i2c_stop();
         return ret;
     }
     for (i = 0; i < count; i++) {
         ret = sensirion_i2c_write_byte(data[i]);
-        if (ret != STATUS_OK) {
+        if (ret != NO_ERROR) {
             sensirion_i2c_stop();
             break;
         }
@@ -154,11 +154,11 @@ int8_t sensirion_i2c_read(uint8_t address, uint8_t* data, uint16_t count) {
     uint16_t i;
 
     ret = sensirion_i2c_start();
-    if (ret != STATUS_OK)
+    if (ret != NO_ERROR)
         return ret;
 
     ret = sensirion_i2c_write_byte((address << 1) | 1);
-    if (ret != STATUS_OK) {
+    if (ret != NO_ERROR) {
         sensirion_i2c_stop();
         return ret;
     }
@@ -168,7 +168,7 @@ int8_t sensirion_i2c_read(uint8_t address, uint8_t* data, uint16_t count) {
     }
 
     sensirion_i2c_stop();
-    return STATUS_OK;
+    return NO_ERROR;
 }
 
 void sensirion_i2c_init(void) {


### PR DESCRIPTION
We use error codes for error handling and drivers define their error
using FOO_ERROR, so using that in the naming is more consistent.