### PR TITLE
Use 'I2C_{SDA,SCL}' constants as default pins

### DIFF
--- a/hw_i2c/sample-implementations/mbed/sensirion_hw_i2c_implementation.cpp
+++ b/hw_i2c/sample-implementations/mbed/sensirion_hw_i2c_implementation.cpp
@@ -37,7 +37,7 @@
 #define E_MBED_I2C_WRITE_FAILED -1
 
 /* open I2C connection */
-static I2C i2c_connection(p28, p27); /* or I2C i2c_connection(p9, p10) */
+static I2C i2c_connection(I2C_SDA, I2C_SCL);
 
 /**
  * Initialize all hard- and software components that are needed for the I2C


### PR DESCRIPTION
MBED boards define constants for the I2C SDA/SCL pins. I'd propose to make this the default (see https://os.mbed.com/docs/mbed-os/v5.15/feature-i2c-doxy/classmbed_1_1_i2_c.html)

Note that I did not update the SW implementation, as I would expect that SW I2C is usually used on non-standard pins