### PR TITLE
Fix byte-to-float conversion issue

### DIFF
--- a/sensirion_common.c
+++ b/sensirion_common.c
@@ -43,7 +43,7 @@ uint32_t sensirion_bytes_to_uint32_t(const uint8_t* bytes) {
            (uint32_t)bytes[2] << 8 | (uint32_t)bytes[3];
 }
 
-uint32_t sensirion_bytes_to_float(const uint8_t* bytes) {
+float sensirion_bytes_to_float(const uint8_t* bytes) {
     union {
         uint32_t u32_value;
         float float32;

--- a/sensirion_common.h
+++ b/sensirion_common.h
@@ -93,15 +93,15 @@ extern "C" {
 uint32_t sensirion_bytes_to_uint32_t(const uint8_t* bytes);
 
 /**
- * sensirion_bytes_to_float() - Convert an array of bytes to an uint32_t
+ * sensirion_bytes_to_float() - Convert an array of bytes to a float
  *
  * Convert an array of bytes received from the sensor in big-endian/MSB-first
- * format to an uint32_t value in the correct system-endianness.
+ * format to an float value in the correct system-endianness.
  *
  * @param bytes An array of at least four bytes (MSB first)
- * @return      The byte array represented as uint32_t
+ * @return      The byte array represented as float
  */
-uint32_t sensirion_bytes_to_float(const uint8_t* bytes);
+float sensirion_bytes_to_float(const uint8_t* bytes);
 
 uint8_t sensirion_common_generate_crc(const uint8_t* data, uint16_t count);
 


### PR DESCRIPTION
The latest version of embedded-common utilities added conversion functions `sensirion_bytes_to_uint32_t` and `sensirion_bytes_to_float`. There seems to have been a copy-paste error resulting in the `sensirion_bytes_to_float` returning `uint32_t` instead, quietly rounding down the reading values.

I have tested the change with an SCD30 driven over hardware I²C by a Raspberry Pi 4 (BCM2711) compiled with GCC and it appears to work fine. The values returned are no longer rounded down and agree with those reported by a nearby BME680 (temperature & relative humidity) within a small margin of error.