### PR TITLE
Remove legacy endianness conversion macros

### DIFF
--- a/sensirion_arch_config.h
+++ b/sensirion_arch_config.h
@@ -69,32 +69,6 @@ extern "C" {
  * typedef unsigned char uint8_t; */
 
 /**
- * Define the endianness of your architecture:
- * 0: little endian, 1: big endian
- * Use the following code to determine if unsure:
- * ```c
- * #include <stdio.h>
- *
- * int is_big_endian(void) {
- *     union {
- *         unsigned int u;
- *         char c[sizeof(unsigned int)];
- *     } e = { 0 };
- *     e.c[0] = 1;
- *
- *     return (e.i != 1);
- * }
- *
- * int main(void) {
- *     printf("Use #define SENSIRION_BIG_ENDIAN %d\n", is_big_endian());
- *
- *     return 0;
- * }
- * ```
- */
-#define SENSIRION_BIG_ENDIAN 0
-
-/**
  * The clock period of the i2c bus in microseconds. Increase this, if your GPIO
  * ports cannot support a 200 kHz output rate. (2 * 1 / 10usec == 200Khz)
  *

--- a/sensirion_common.h
+++ b/sensirion_common.h
@@ -43,33 +43,6 @@ extern "C" {
 #define STATUS_OK 0
 #define STATUS_FAIL (-1)
 
-#if SENSIRION_BIG_ENDIAN
-#define be16_to_cpu(s) (s)
-#define be32_to_cpu(s) (s)
-#define be64_to_cpu(s) (s)
-#define SENSIRION_WORDS_TO_BYTES(a, w) ()
-
-#else /* SENSIRION_BIG_ENDIAN */
-
-#define be16_to_cpu(s) (((uint16_t)(s) << 8) | (0xff & ((uint16_t)(s)) >> 8))
-#define be32_to_cpu(s) \
-    (((uint32_t)be16_to_cpu(s) << 16) | (0xffff & (be16_to_cpu((s) >> 16))))
-#define be64_to_cpu(s)                  \
-    (((uint64_t)be32_to_cpu(s) << 32) | \
-     (0xffffffff & ((uint64_t)be32_to_cpu((s) >> 32))))
-/**
- * Convert a word-array to a bytes-array, effectively reverting the
- * host-endianness to big-endian
- * @a:  word array to change (must be (uint16_t *) castable)
- * @w:  number of word-sized elements in the array (SENSIRION_NUM_WORDS(a)).
- */
-#define SENSIRION_WORDS_TO_BYTES(a, w)                                  \
-    for (uint16_t* __a = (uint16_t*)(a), __e = (w), __w = 0; __w < __e; \
-         ++__w) {                                                       \
-        __a[__w] = be16_to_cpu(__a[__w]);                               \
-    }
-#endif /* SENSIRION_BIG_ENDIAN */
-
 #ifndef ARRAY_SIZE
 #define ARRAY_SIZE(x) (sizeof(x) / sizeof(*(x)))
 #endif


### PR DESCRIPTION
All drivers are migrated or in the process of being migrated, so we can remove these for the next version and avoid confusing users with it.