### PR TITLE
Add Zephyr User-Space sample implementation

### DIFF
--- a/hw_i2c/sample-implementations/zephyr_user_space/sensirion_hw_i2c_implementation.c
+++ b/hw_i2c/sample-implementations/zephyr_user_space/sensirion_hw_i2c_implementation.c
@@ -1,0 +1,125 @@
+/*
+ * Copyright (c) 2018, Sensirion AG
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of Sensirion AG nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <device.h>
+#include <drivers/i2c.h>
+#include <unistd.h>
+#include <zephyr.h>
+
+#include "sensirion_arch_config.h"
+#include "sensirion_common.h"
+#include "sensirion_i2c.h"
+
+/* I2C device. */
+static struct device* i2c_dev;
+
+/**
+ * Select the current i2c bus by index.
+ * All following i2c operations will be directed at that bus.
+ *
+ * @param bus_idx   Bus index to select
+ * @returns         0 on success, an error code otherwise
+ */
+int16_t sensirion_i2c_select_bus(uint8_t bus_idx) {
+    char bus_name[6] = "I2C_0";
+
+    if (bus_idx > 9) {
+        /* Invalid bus index */
+        return STATUS_FAIL;
+    }
+
+    bus_name[4] = bus_idx + '0';
+    i2c_dev = device_get_binding(bus_name);
+    if (i2c_dev == NULL) {
+        /* No valid device found */
+        return STATUS_FAIL;
+    }
+
+    return STATUS_OK;
+}
+
+/**
+ * Initialize all hard- and software components that are needed for the I2C
+ * communication.
+ */
+void sensirion_i2c_init(void) {
+    /* Device (specified by sps30_i2c_dev) is already initialized by the Zephyr
+     * boot-up process. Nothing to be done here. */
+}
+
+/**
+ * Release all resources initialized by sensirion_i2c_init().
+ */
+void sensirion_i2c_release(void) {
+    i2c_dev = NULL;
+}
+
+/**
+ * Execute one read transaction on the I2C bus, reading a given number of bytes.
+ * If the device does not acknowledge the read command, an error shall be
+ * returned.
+ *
+ * @param address 7-bit I2C address to read from
+ * @param data    pointer to the buffer where the data is to be stored
+ * @param count   number of bytes to read from I2C and store in the buffer
+ * @returns 0 on success, error code otherwise
+ */
+int8_t sensirion_i2c_read(uint8_t address, uint8_t* data, uint16_t count) {
+    return i2c_read(i2c_dev, data, count, address);
+}
+
+/**
+ * Execute one write transaction on the I2C bus, sending a given number of
+ * bytes. The bytes in the supplied buffer must be sent to the given address. If
+ * the slave device does not acknowledge any of the bytes, an error shall be
+ * returned.
+ *
+ * @param address 7-bit I2C address to write to
+ * @param data    pointer to the buffer containing the data to write
+ * @param count   number of bytes to read from the buffer and send over I2C
+ * @returns 0 on success, error code otherwise
+ */
+int8_t sensirion_i2c_write(uint8_t address, const uint8_t* data,
+                           uint16_t count) {
+    return i2c_write(i2c_dev, data, count, address);
+}
+
+/**
+ * Sleep for a given number of microseconds. The function should delay the
+ * execution for at least the given time, but may also sleep longer.
+ *
+ * Despite the unit, a <10 millisecond precision is sufficient.
+ *
+ * @param useconds the sleep time in microseconds
+ */
+void sensirion_sleep_usec(uint32_t useconds) {
+    usleep(useconds);
+}


### PR DESCRIPTION
Porting the SPS30 driver to Zephyr User-Space (https://github.com/zephyrproject-rtos/zephyr). Tested with nRF9160 and STM32L4.