### PR TITLE
Add general configuration for tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ files) from the respective projects:
   including sample code for some platforms)
 * `sw_i2c` folder (stub for implementation of the software i2c communication
   (bit-banging GPIOs), including sample code for some platforms)
+* `test-config` folder (configuration files for tests, used by driver repositories)
 
 ### sensirion\_arch\_config.h
 You need to specify the integer sizes on your system.

--- a/test-config/base_config.inc
+++ b/test-config/base_config.inc
@@ -1,0 +1,17 @@
+driver_dir := ../../
+mux_dir := ../i2c-mux-testbed
+test_common_dir := ../embedded-common/test-config
+
+# Unlike colon-equal (:=) immediate assignments, the simple equal sign (=) lazy
+# assignment is lazility evaluated, so resorting to ${sensirion_common_dir}
+# which is not yet defined works.
+i2c_mux_sources = ${mux_dir}/i2c_mux.h ${mux_dir}/i2c_mux.c
+hw_i2c_impl_src = ${sensirion_common_dir}/hw_i2c/sample-implementations/linux_user_space/sensirion_hw_i2c_implementation.c
+sw_i2c_impl_src = ${sensirion_common_dir}/sw_i2c/sample-implementations/linux_user_space/sensirion_sw_i2c_implementation.c
+
+sensirion_test_sources := ${test_common_dir}/sensirion_test_setup.h \
+                          ${test_common_dir}/sensirion_test_setup.cpp \
+                          ${i2c_mux_sources}
+
+CXXFLAGS ?= $(CFLAGS) -fsanitize=address -I${mux_dir} -I${test_common_dir}
+LDFLAGS ?= -lasan -lstdc++ -lCppUTest -lCppUTestExt

--- a/test-config/sensirion_test_setup.cpp
+++ b/test-config/sensirion_test_setup.cpp
@@ -1,0 +1,12 @@
+#include "CppUTest/CommandLineTestRunner.h"
+
+#include "sensirion_i2c.h"
+
+int16_t i2c_reset() {
+    const uint8_t reset_data[] = {0x06};
+    return sensirion_i2c_write(0x00, reset_data, (uint16_t)sizeof(reset_data));
+}
+
+int main(int argc, char** argv) {
+    return CommandLineTestRunner::RunAllTests(argc, argv);
+}

--- a/test-config/sensirion_test_setup.cpp
+++ b/test-config/sensirion_test_setup.cpp
@@ -1,10 +1,9 @@
 #include "CppUTest/CommandLineTestRunner.h"
 
-#include "sensirion_i2c.h"
+#include "sensirion_common.h"
 
 int16_t i2c_reset() {
-    const uint8_t reset_data[] = {0x06};
-    return sensirion_i2c_write(0x00, reset_data, (uint16_t)sizeof(reset_data));
+    return sensirion_i2c_general_call_reset();
 }
 
 int main(int argc, char** argv) {

--- a/test-config/sensirion_test_setup.h
+++ b/test-config/sensirion_test_setup.h
@@ -1,0 +1,17 @@
+#ifndef SENSIRION_TEST_SETUP_H
+#define SENSIRION_TEST_SETUP_H
+
+#include <stdio.h>
+
+#include "CppUTest/TestHarness.h"
+
+#include "i2c_mux.h"
+
+#define CHECK_ZERO(actual) CHECK_EQUAL(0, (actual))
+#define CHECK_ZERO_TEXT(actual, text) CHECK_EQUAL_TEXT(0, (actual), (text))
+
+int16_t i2c_reset();
+
+int main(int argc, char** argv);
+
+#endif /* SENSIRION_TEST_SETUP_H */


### PR DESCRIPTION
In an effort to move tests to be with the driver repo and not on there
own, the general configuration files for this setup are with the
embedded common repo. Add those configuration files.