### PR TITLE
Use Zephyr Native k_usleep instead of POSIX usleep

### DIFF
--- a/hw_i2c/sample-implementations/zephyr_user_space/sensirion_hw_i2c_implementation.c
+++ b/hw_i2c/sample-implementations/zephyr_user_space/sensirion_hw_i2c_implementation.c
@@ -120,5 +120,8 @@ int8_t sensirion_i2c_write(uint8_t address, const uint8_t* data,
  * @param useconds the sleep time in microseconds
  */
 void sensirion_sleep_usec(uint32_t useconds) {
-    k_usleep(useconds);
+    int32_t remaining = useconds;
+    while (remaining > 0) {
+        remaining = k_usleep(remaining);
+    }
 }

--- a/hw_i2c/sample-implementations/zephyr_user_space/sensirion_hw_i2c_implementation.c
+++ b/hw_i2c/sample-implementations/zephyr_user_space/sensirion_hw_i2c_implementation.c
@@ -31,7 +31,6 @@
 
 #include <device.h>
 #include <drivers/i2c.h>
-#include <unistd.h>
 #include <zephyr.h>
 
 #include "sensirion_arch_config.h"
@@ -121,5 +120,5 @@ int8_t sensirion_i2c_write(uint8_t address, const uint8_t* data,
  * @param useconds the sleep time in microseconds
  */
 void sensirion_sleep_usec(uint32_t useconds) {
-    usleep(useconds);
+    k_usleep(useconds);
 }


### PR DESCRIPTION
Both k_usleep / usleep provide the same functionality, but "usleep" requires the support of POSIX to be enabled in the zephyr build, which increases the image size. As the same functionality can be achieved by using the native "k_usleep" without additional memory usage, it should be preferred over "usleep".