### PR TITLE
Add function sensirion_bytes_to_uint16_t

### DIFF
--- a/sensirion_common.c
+++ b/sensirion_common.c
@@ -38,6 +38,10 @@
 #include "sensirion_common.h"
 #include "sensirion_i2c.h"
 
+uint16_t sensirion_bytes_to_uint16_t(const uint8_t* bytes) {
+    return (uint16_t)bytes[0] << 8 | (uint16_t)bytes[1];
+}
+
 uint32_t sensirion_bytes_to_uint32_t(const uint8_t* bytes) {
     return (uint32_t)bytes[0] << 24 | (uint32_t)bytes[1] << 16 |
            (uint32_t)bytes[2] << 8 | (uint32_t)bytes[3];

--- a/sensirion_common.h
+++ b/sensirion_common.h
@@ -57,6 +57,17 @@ extern "C" {
 #define SENSIRION_MAX_BUFFER_WORDS 32
 
 /**
+ * sensirion_bytes_to_uint16_t() - Convert an array of bytes to an uint16_t
+ *
+ * Convert an array of bytes received from the sensor in big-endian/MSB-first
+ * format to an uint16_t value in the correct system-endianness.
+ *
+ * @param bytes An array of at least two bytes (MSB first)
+ * @return      The byte array represented as uint16_t
+ */
+uint16_t sensirion_bytes_to_uint16_t(const uint8_t* bytes);
+
+/**
  * sensirion_bytes_to_uint32_t() - Convert an array of bytes to an uint32_t
  *
  * Convert an array of bytes received from the sensor in big-endian/MSB-first


### PR DESCRIPTION
Add function sensirion_bytes_to_uint16_t since it's needed for the
SEN44 driver and in general a useful addition.