### PR TITLE
Remove deprecated i2c_reset

### DIFF
--- a/test-config/sensirion_test_setup.cpp
+++ b/test-config/sensirion_test_setup.cpp
@@ -1,11 +1,5 @@
 #include "CppUTest/CommandLineTestRunner.h"
 
-#include "sensirion_common.h"
-
-int16_t i2c_reset() {
-    return sensirion_i2c_general_call_reset();
-}
-
 int main(int argc, char** argv) {
     return CommandLineTestRunner::RunAllTests(argc, argv);
 }

--- a/test-config/sensirion_test_setup.h
+++ b/test-config/sensirion_test_setup.h
@@ -10,8 +10,6 @@
 #define CHECK_ZERO(actual) CHECK_EQUAL(0, (actual))
 #define CHECK_ZERO_TEXT(actual, text) CHECK_EQUAL_TEXT(0, (actual), (text))
 
-int16_t i2c_reset();
-
 int main(int argc, char** argv);
 
 #endif /* SENSIRION_TEST_SETUP_H */


### PR DESCRIPTION
Just use sensirion_i2c_general_call_reset  directly.