### PR TITLE
Check if execution of command failed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+ * [`fixed`]   handling of execution errors when using the SHDLC protocol. Now
+               execution errors reported in the state byte result in an error.
  * [`added`]   function `sensirion_common_copy_bytes()` to `sensirion_common.[ch]`
                to copy bytes from one buffer to another one.
 
@@ -58,4 +60,3 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [0.2.0]: https://github.com/Sensirion/embedded-common/compare/0.1.0...0.2.0
 [0.1.0]: https://github.com/Sensirion/embedded-common/releases/tag/0.1.0
 [embedded-uart-common]: https://github.com/Sensirion/embedded-uart-sps/tree/f31d181/embedded-uart-common
-

--- a/shdlc/sensirion_shdlc.c
+++ b/shdlc/sensirion_shdlc.c
@@ -199,5 +199,9 @@ int16_t sensirion_shdlc_rx(uint8_t max_data_len,
     if (i >= len || rx_frame[i] != SHDLC_STOP)
         return SENSIRION_SHDLC_ERR_MISSING_STOP;
 
+    if (0x7F & rxh->state) {
+        return SENSIRION_SHDLC_ERR_EXECUTION_FAILURE;
+    }
+
     return 0;
 }

--- a/shdlc/sensirion_shdlc.h
+++ b/shdlc/sensirion_shdlc.h
@@ -45,6 +45,7 @@ extern "C" {
 #define SENSIRION_SHDLC_ERR_ENCODING_ERROR -5
 #define SENSIRION_SHDLC_ERR_TX_INCOMPLETE -6
 #define SENSIRION_SHDLC_ERR_FRAME_TOO_LONG -7
+#define SENSIRION_SHDLC_ERR_EXECUTION_FAILURE -8
 
 struct sensirion_shdlc_rx_header {
     uint8_t addr;


### PR DESCRIPTION
Fixed the handling of execution errors when using the SHDLC protocol. Now execution errors reported in the state byte result in a error.