### PR TITLE
Check if execution of command failed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+ * [`fixed`]   handling of execution errors when using the SHDLC protocol. Now
+               execution errors reported in the state byte result in a error.
  * [`added`]   tests to embedded-common.
  * [`added`]   incremental frame construction to SHLDC. This includes a set of
                functions to create a frame step by step. For all used data types

--- a/shdlc/sensirion_shdlc.c
+++ b/shdlc/sensirion_shdlc.c
@@ -199,6 +199,10 @@ int16_t sensirion_shdlc_rx(uint8_t max_data_len,
     if (i >= len || rx_frame[i] != SHDLC_STOP)
         return SENSIRION_SHDLC_ERR_MISSING_STOP;
 
+    if (0x7F & rxh->state) {
+        return SENSIRION_SHDLC_ERR_EXECUTION_FAILURE;
+    }
+
     return 0;
 }
 
@@ -366,6 +370,10 @@ int16_t sensirion_shdlc_rx_inplace(struct sensirion_shdlc_buffer* rx_frame,
     if (rx_frame->offset >= rx_length ||
         rx_frame->data[rx_frame->offset] != SHDLC_STOP) {
         return SENSIRION_SHDLC_ERR_MISSING_STOP;
+    }
+
+    if (0x7F & header->state) {
+        return SENSIRION_SHDLC_ERR_EXECUTION_FAILURE;
     }
 
     return NO_ERROR;

--- a/shdlc/sensirion_shdlc.h
+++ b/shdlc/sensirion_shdlc.h
@@ -45,6 +45,7 @@ extern "C" {
 #define SENSIRION_SHDLC_ERR_ENCODING_ERROR -5
 #define SENSIRION_SHDLC_ERR_TX_INCOMPLETE -6
 #define SENSIRION_SHDLC_ERR_FRAME_TOO_LONG -7
+#define SENSIRION_SHDLC_ERR_EXECUTION_FAILURE -8
 
 struct sensirion_shdlc_buffer {
     uint8_t* data;


### PR DESCRIPTION
Fix the handling of execution errors when using the SHDLC protocol. Now execution errors reported in the state byte result in a error.