### PR TITLE
Change count to uint8_t

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.0] - 2023-03-20
+ * [`changed`] `sensirion_i2c_hal.h` change interface of count from uint16_t
+               to uint8_t.
+
+
 ## [0.4.0] - 2021-10-22
 
  * [`added`]   `const` modifier to functions which process MOSI array data.

--- a/i2c/sample-implementations/Atmel_SAMD2_series/sensirion_i2c_hal.c
+++ b/i2c/sample-implementations/Atmel_SAMD2_series/sensirion_i2c_hal.c
@@ -57,7 +57,7 @@ void sensirion_i2c_hal_init(void) {
 void sensirion_i2c_hal_free(void) {
 }
 
-int8_t sensirion_i2c_hal_read(uint8_t address, uint8_t* data, uint16_t count) {
+int8_t sensirion_i2c_hal_read(uint8_t address, uint8_t* data, uint8_t count) {
     struct i2c_master_packet packet = {
         .address = address,
         .data_length = count,
@@ -69,7 +69,7 @@ int8_t sensirion_i2c_hal_read(uint8_t address, uint8_t* data, uint16_t count) {
 }
 
 int8_t sensirion_i2c_hal_write(uint8_t address, const uint8_t* data,
-                               uint16_t count) {
+                               uint8_t count) {
     struct i2c_master_packet packet = {
         .address = address,
         .data_length = count,

--- a/i2c/sample-implementations/GPIO_bit_banging/sensirion_i2c_hal.c
+++ b/i2c/sample-implementations/GPIO_bit_banging/sensirion_i2c_hal.c
@@ -88,10 +88,10 @@ void sensirion_i2c_hal_free(void) {
  * @param count   number of bytes to read from I2C and store in the buffer
  * @returns 0 on success, error code otherwise
  */
-int8_t sensirion_i2c_hal_read(uint8_t address, uint8_t* data, uint16_t count) {
+int8_t sensirion_i2c_hal_read(uint8_t address, uint8_t* data, uint8_t count) {
     int8_t ret;
     uint8_t send_ack;
-    uint16_t i;
+    uint8_t i;
 
     ret = sensirion_i2c_gpio_start();
     if (ret != NO_ERROR)
@@ -123,9 +123,9 @@ int8_t sensirion_i2c_hal_read(uint8_t address, uint8_t* data, uint16_t count) {
  * @returns 0 on success, error code otherwise
  */
 int8_t sensirion_i2c_hal_write(uint8_t address, const uint8_t* data,
-                               uint16_t count) {
+                               uint8_t count) {
     int8_t ret;
-    uint16_t i;
+    uint8_t i;
 
     ret = sensirion_i2c_gpio_start();
     if (ret != NO_ERROR)

--- a/i2c/sample-implementations/Nordic_nRF5_series/sensirion_i2c_hal.c
+++ b/i2c/sample-implementations/Nordic_nRF5_series/sensirion_i2c_hal.c
@@ -92,8 +92,8 @@ void sensirion_i2c_hal_free(void) {
  * error codes:  3 -> error detected by hardware (internal error)
  *              17 -> driver not ready for new transfer (busy)
  */
-int8_t sensirion_i2c_hal_read(uint8_t address, uint8_t* data, uint16_t count) {
-    int8_t err = nrf_drv_twi_rx(&i2c_instance, address, data, (uint8_t)count);
+int8_t sensirion_i2c_hal_read(uint8_t address, uint8_t* data, uint8_t count) {
+    int8_t err = nrf_drv_twi_rx(&i2c_instance, address, data, count);
     return err;
 }
 
@@ -112,9 +112,8 @@ int8_t sensirion_i2c_hal_read(uint8_t address, uint8_t* data, uint16_t count) {
  *              17 -> driver not ready for new transfer (busy)
  */
 int8_t sensirion_i2c_hal_write(uint8_t address, const uint8_t* data,
-                               uint16_t count) {
-    int8_t err =
-        nrf_drv_twi_tx(&i2c_instance, address, data, (uint8_t)count, false);
+                               uint8_t count) {
+    int8_t err = nrf_drv_twi_tx(&i2c_instance, address, data, count, false);
     return err;
 }
 

--- a/i2c/sample-implementations/STM32F1_series/sensirion_i2c_hal.c
+++ b/i2c/sample-implementations/STM32F1_series/sensirion_i2c_hal.c
@@ -79,7 +79,7 @@ void sensirion_i2c_hal_free(void) {
  * @param count   number of bytes to read from I2C and store in the buffer
  * @returns 0 on success, error code otherwise
  */
-int8_t sensirion_i2c_hal_read(uint8_t address, uint8_t* data, uint16_t count) {
+int8_t sensirion_i2c_hal_read(uint8_t address, uint8_t* data, uint8_t count) {
     return (int8_t)HAL_I2C_Master_Receive(&hi2c1, (uint16_t)(address << 1),
                                           data, count, 100);
 }
@@ -96,7 +96,7 @@ int8_t sensirion_i2c_hal_read(uint8_t address, uint8_t* data, uint16_t count) {
  * @returns 0 on success, error code otherwise
  */
 int8_t sensirion_i2c_hal_write(uint8_t address, const uint8_t* data,
-                               uint16_t count) {
+                               uint8_t count) {
     return (int8_t)HAL_I2C_Master_Transmit(&hi2c1, (uint16_t)(address << 1),
                                            (uint8_t*)data, count, 100);
 }

--- a/i2c/sample-implementations/linux_user_space/sensirion_i2c_hal.c
+++ b/i2c/sample-implementations/linux_user_space/sensirion_i2c_hal.c
@@ -89,7 +89,7 @@ void sensirion_i2c_hal_free(void) {
  * @param count   number of bytes to read from I2C and store in the buffer
  * @returns 0 on success, error code otherwise
  */
-int8_t sensirion_i2c_hal_read(uint8_t address, uint8_t* data, uint16_t count) {
+int8_t sensirion_i2c_hal_read(uint8_t address, uint8_t* data, uint8_t count) {
     if (i2c_address != address) {
         ioctl(i2c_device, I2C_SLAVE, address);
         i2c_address = address;
@@ -113,7 +113,7 @@ int8_t sensirion_i2c_hal_read(uint8_t address, uint8_t* data, uint16_t count) {
  * @returns 0 on success, error code otherwise
  */
 int8_t sensirion_i2c_hal_write(uint8_t address, const uint8_t* data,
-                               uint16_t count) {
+                               uint8_t count) {
     if (i2c_address != address) {
         ioctl(i2c_device, I2C_SLAVE, address);
         i2c_address = address;

--- a/i2c/sample-implementations/mbed/sensirion_i2c_hal.cpp
+++ b/i2c/sample-implementations/mbed/sensirion_i2c_hal.cpp
@@ -63,7 +63,7 @@ void sensirion_i2c_hal_free(void) {
  * @param count   number of bytes to read from I2C and store in the buffer
  * @returns 0 on success, error code otherwise
  */
-int8_t sensirion_i2c_hal_read(uint8_t address, uint8_t* data, uint16_t count) {
+int8_t sensirion_i2c_hal_read(uint8_t address, uint8_t* data, uint8_t count) {
     if (i2c_connection.read(address << 1, (char*)data, count) != 0)
         return E_MBED_I2C_READ_FAILED;
     return 0;
@@ -81,7 +81,7 @@ int8_t sensirion_i2c_hal_read(uint8_t address, uint8_t* data, uint16_t count) {
  * @returns 0 on success, error code otherwise
  */
 int8_t sensirion_i2c_hal_write(uint8_t address, const uint8_t* data,
-                               uint16_t count) {
+                               uint8_t count) {
     if (i2c_connection.write(address << 1, (char*)data, count) != 0)
         return E_MBED_I2C_WRITE_FAILED;
     return 0;

--- a/i2c/sample-implementations/zephyr_user_space/sensirion_i2c_hal.c
+++ b/i2c/sample-implementations/zephyr_user_space/sensirion_i2c_hal.c
@@ -91,7 +91,7 @@ void sensirion_i2c_hal_free(void) {
  * @param count   number of bytes to read from I2C and store in the buffer
  * @returns 0 on success, error code otherwise
  */
-int8_t sensirion_i2c_hal_read(uint8_t address, uint8_t* data, uint16_t count) {
+int8_t sensirion_i2c_hal_read(uint8_t address, uint8_t* data, uint8_t count) {
     return i2c_read(i2c_dev, data, count, address);
 }
 
@@ -107,7 +107,7 @@ int8_t sensirion_i2c_hal_read(uint8_t address, uint8_t* data, uint16_t count) {
  * @returns 0 on success, error code otherwise
  */
 int8_t sensirion_i2c_hal_write(uint8_t address, const uint8_t* data,
-                               uint16_t count) {
+                               uint8_t count) {
     return i2c_write(i2c_dev, data, count, address);
 }
 

--- a/i2c/sensirion_i2c_hal.c
+++ b/i2c/sensirion_i2c_hal.c
@@ -83,7 +83,7 @@ void sensirion_i2c_hal_free(void) {
  * @param count   number of bytes to read from I2C and store in the buffer
  * @returns 0 on success, error code otherwise
  */
-int8_t sensirion_i2c_hal_read(uint8_t address, uint8_t* data, uint16_t count) {
+int8_t sensirion_i2c_hal_read(uint8_t address, uint8_t* data, uint8_t count) {
     /* TODO:IMPLEMENT */
     return NOT_IMPLEMENTED_ERROR;
 }
@@ -100,7 +100,7 @@ int8_t sensirion_i2c_hal_read(uint8_t address, uint8_t* data, uint16_t count) {
  * @returns 0 on success, error code otherwise
  */
 int8_t sensirion_i2c_hal_write(uint8_t address, const uint8_t* data,
-                               uint16_t count) {
+                               uint8_t count) {
     /* TODO:IMPLEMENT */
     return NOT_IMPLEMENTED_ERROR;
 }

--- a/i2c/sensirion_i2c_hal.h
+++ b/i2c/sensirion_i2c_hal.h
@@ -71,7 +71,7 @@ void sensirion_i2c_hal_free(void);
  * @param count   number of bytes to read from I2C and store in the buffer
  * @returns 0 on success, error code otherwise
  */
-int8_t sensirion_i2c_hal_read(uint8_t address, uint8_t* data, uint16_t count);
+int8_t sensirion_i2c_hal_read(uint8_t address, uint8_t* data, uint8_t count);
 
 /**
  * Execute one write transaction on the I2C bus, sending a given number of
@@ -85,7 +85,7 @@ int8_t sensirion_i2c_hal_read(uint8_t address, uint8_t* data, uint16_t count);
  * @returns 0 on success, error code otherwise
  */
 int8_t sensirion_i2c_hal_write(uint8_t address, const uint8_t* data,
-                               uint16_t count);
+                               uint8_t count);
 
 /**
  * Sleep for a given number of microseconds. The function should delay the


### PR DESCRIPTION
Change count for Sensirion I2C HAL from uint16_t to unit8_t. We never have a count that requires 16-bit integers, therefore we can safely change it to 8-bit.
This avoids compiler warnings on some platforms.